### PR TITLE
fix:회원가입 페이지 추가 수정

### DIFF
--- a/perfectJournal/new_diagram.uxf
+++ b/perfectJournal/new_diagram.uxf
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><umlet_diagram></umlet_diagram>

--- a/perfectJournal/src/main/java/com/pj/journal/controller/UserController.java
+++ b/perfectJournal/src/main/java/com/pj/journal/controller/UserController.java
@@ -135,7 +135,6 @@ public class UserController {
 	@PostMapping("/users/signup")
 	public String register(@ModelAttribute UserVo bean, Model model) {
 		if (userService.isIdAlreadyExists(bean.getUser()) > 0) {
-			bean.setUser(null);
 			bean.setPassword(null);
 			model.addAttribute("signupError", "이미 사용중인 아이디입니다.");
 			model.addAttribute("user", bean);
@@ -143,7 +142,6 @@ public class UserController {
 		}
 
 		if (!bean.getUser().matches("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,15}$")) {
-			bean.setUser(null);
 			bean.setPassword(null);
 			model.addAttribute("signupError", "아이디는 영문자와 숫자를 모두 포함해야 하며, 8~15자여야 합니다. 특수문자는 사용할 수 없습니다.");
 			model.addAttribute("user", bean);
@@ -151,10 +149,13 @@ public class UserController {
 		}
 
 		if (!bean.getPassword()
-				.matches("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,}$")) {
-			model.addAttribute("signupError", "비밀번호는 8자 이상이며, 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다.");
-			return "user/register";
+		        .matches("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,}$")) {
+		    bean.setPassword(null);
+		    model.addAttribute("signupError", "비밀번호는 8자 이상이며, 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다.");
+		    model.addAttribute("user", bean);
+		    return "user/register";
 		}
+
 
 		if (userService.isEmailAlreadyExists(bean.getEmail()) > 0) {
 			model.addAttribute("signupError", "이미 사용중인 이메일입니다.");


### PR DESCRIPTION
### PR 요약 (Pull Request Summary)
비밀번호 유효성 검사 실패 시 입력값 유지 안 되는 문제 수정

### 주요 변경 사항
- 비밀번호 조건 불충족 시 `model.addAttribute("user", bean)` 누락된 부분 추가
- 비밀번호 외 입력값이 정상적으로 유지되도록 컨트롤러 로직 수정

### 변경 이유
- 비밀번호 유효성 검사 실패 시, 아이디/이메일/닉네임 등의 입력값이 초기화되는 UX 문제 발생
- 다른 유효성 검사 실패와 동일하게 입력값이 유지되도록 처리하여 사용자 편의성 개선
